### PR TITLE
有些浏览器插件会在html中插入样式链接，导致切换主题失效

### DIFF
--- a/site/src/pages/layout.js
+++ b/site/src/pages/layout.js
@@ -4,7 +4,7 @@ import './layout.styl';
 
 let theme;
 function changeTheme(newTheme, oldTheme) {
-    const link = document.querySelector('link[rel=stylesheet]');
+    const link = document.querySelector('head link[rel=stylesheet]');
     if (!link) return;
 
     link.href = link.href.replace(`theme-${oldTheme}`, `theme-${newTheme}`);
@@ -35,6 +35,7 @@ export default class extends Intact {
 
     _init() {
         this.on('$change:theme', (c, v, o) => {
+            console.log(v, o)
             changeTheme(v, o);
         });
     }

--- a/site/src/pages/layout.js
+++ b/site/src/pages/layout.js
@@ -4,7 +4,7 @@ import './layout.styl';
 
 let theme;
 function changeTheme(newTheme, oldTheme) {
-    const link = document.querySelector('head link[rel=stylesheet]');
+    const link = document.querySelector('link[href^=http]');
     if (!link) return;
 
     link.href = link.href.replace(`theme-${oldTheme}`, `theme-${newTheme}`);


### PR DESCRIPTION
我使用的一款叫Liner的标记插件，会在HTML中插入样式链接。
![image](https://user-images.githubusercontent.com/1564444/59336046-68efbf80-8d30-11e9-9f6e-530d3627797d.png)

切换样式时，选择器会选中插件链接，而且无法修改。故有此pr