### PR TITLE
feat: 移除每次选择筛选内容后自动清空筛选条件

### DIFF
--- a/components/select/index.vdt
+++ b/components/select/index.vdt
@@ -67,9 +67,11 @@ const setHasOnlyOneValidOptionAndSelected = active => {
 const allShowedValues = [];
 
 const WrapCheckbox = (props) => {
-    return <Checkbox v-model="_checkedKeys" trueValue={{ props.value }}
-        ev-click={{ self._resetSearch }}
-    >{{ props.children }}</Checkbox>
+    return (
+        <Checkbox v-model="_checkedKeys" trueValue={{ props.value }}>
+            {{ props.children }}
+        </Checkbox>
+    )
 };
 
 const Options = props => {


### PR DESCRIPTION
在筛选结果过多时，有时需要同时选择多个结果，但是清空筛选条件，会导致选择一个就清空筛选结果，不方便多个选择。