### PR TITLE
fix: typo

### DIFF
--- a/components/button/demos/group.md
+++ b/components/button/demos/group.md
@@ -4,7 +4,7 @@ order: 1
 ---
 
 将`Button`作为`ButtonGroup`的子元素，可以展示按钮组。给`ButtonGroup`添加`vertical`属性，
-可以是按钮组纵向排列。给`ButtonGroup`添加`checkType`属性，可以使按钮组拥有单选或复选能力。
+可以使按钮组纵向排列。给`ButtonGroup`添加`separate`属性，可以在按钮之间插入间隔。给`ButtonGroup`添加`checkType`属性，可以使按钮组拥有单选或复选能力。
 
 ```vdt
 import {Button, ButtonGroup, Icon} from 'kpc';
@@ -62,13 +62,13 @@ import {Button, ButtonGroup, Icon} from 'kpc';
         <Button value="shenzhen" size="small">深圳</Button>
     </ButtonGroup>
     <p>有间隔的按钮组</p>
-    <ButtonGroup checkType="radio" v-model="city" seperate>
+    <ButtonGroup checkType="radio" v-model="city" separate>
         <Button value="beijing">北京</Button>
         <Button value="shanghai">上海</Button>
         <Button value="guangzhou">广州</Button>
         <Button value="shenzhen">深圳</Button>
     </ButtonGroup>
-    <ButtonGroup seperate>
+    <ButtonGroup separate>
         <Button value="beijing" type="primary" disabled>北京</Button>
         <Button value="shanghai">上海</Button>
         <Button value="guangzhou">广州</Button>

--- a/components/button/group.ts
+++ b/components/button/group.ts
@@ -10,6 +10,7 @@ export interface ButtonGroupProps {
     checkType?: 'none' | 'radio' | 'checkbox' 
     fluid?: boolean
     seperate?: boolean
+    separate?: boolean
     btnWidth?: number | string
 }
 
@@ -19,6 +20,7 @@ const typeDefs: Required<TypeDefs<ButtonGroupProps>> = {
     fluid: Boolean,
     checkType: ['none', 'radio', 'checkbox'],
     seperate: Boolean,
+    separate: Boolean,
     btnWidth: [Number, String],
 };
 
@@ -35,6 +37,9 @@ export class ButtonGroup extends Component<ButtonGroupProps> {
 
     init() {
         provide(BUTTON_GROUP, this); 
+        if (typeof this.get().seperate === 'boolean') {
+            console.warn("`seperate` is a typo which will be removed in next version, please using `separate` instead");
+        }
     }
 
     setValue(v: any): void {

--- a/components/button/group.vdt
+++ b/components/button/group.vdt
@@ -1,14 +1,14 @@
 import {getRestProps} from '../utils';
 import {makeButtonGroupStyles} from './styles';
 
-const {className, vertical, children, fluid, seperate} = this.get();
+const {className, vertical, children, fluid, seperate, separate} = this.get();
 const {k} = this.config;
 
 const classNameObj = {
     [`${k}-btns`]: true,
     [`${k}-vertical`]: vertical,
     [`${k}-fluid`]: fluid,
-    [`${k}-seperate`]: seperate,
+    [`${k}-separate`]: typeof separate === 'boolean' ? separate : separate,
     [className]: className,
     [makeButtonGroupStyles(k)]: true,
 };

--- a/components/button/index.md
+++ b/components/button/index.md
@@ -33,7 +33,8 @@ sidebar: doc
 | checkType | 指定按钮组为单选或复选类型，此时需要给每个按钮指定`value`来作为选中的值 | `"radio"` &#124; `"checkbox"` &#124; `"none"` | `"none"` |
 | value | 对于`radio`和`checkbox`类型按钮组，该值表示选中的按钮的值，可以使用`v-model`进行双向绑定 | `*` | `undefined` |
 | fluid | 是否宽度100% | `boolean` | `false` |
-| seperate | 是否展示间隔 | `boolean` | `false` |
+| seperate | 是否展示间隔，此属性为错别字，将会在下个版本被删除，请使用正确的属性 `separate`，若两个属性同时使用，则会优先使用`separate`属性 | `boolean` | `false` |
+| separate | 是否展示间隔 | `boolean` | `false` |
 
 # 方法
 

--- a/components/button/styles.ts
+++ b/components/button/styles.ts
@@ -502,7 +502,7 @@ export const makeButtonGroupStyles = cache(function makeButtonGroupStyles(k: str
         }
 
         // horizontal
-        &:not(.${k}-vertical):not(.${k}-seperate) {
+        &:not(.${k}-vertical):not(.${k}-separate) {
             > .${k}-btn {
                 &:not(:first-child) {
                     margin-left: -1px;
@@ -540,7 +540,7 @@ export const makeButtonGroupStyles = cache(function makeButtonGroupStyles(k: str
         }
             
         // vertical
-        &.${k}-vertical:not(.${k}-seperate) {
+        &.${k}-vertical:not(.${k}-separate) {
             flex-direction: column;
             > .${k}-btn {
                 &:not(.${k}-btn-icon) {
@@ -575,8 +575,8 @@ export const makeButtonGroupStyles = cache(function makeButtonGroupStyles(k: str
             }
         }
 
-        // seperate
-        &.${k}-seperate {
+        // separate
+        &.${k}-separate {
             gap: 8px;
         }
     `;


### PR DESCRIPTION
`ButtonGroup` 的 `seperate` 是一个错别字，应该使用 `separate`。此 pr 用于修复此问题