### PR TITLE
docs: add KPC AI CLI and MCP usage guides

### DIFF
--- a/docs/ai-cli.md
+++ b/docs/ai-cli.md
@@ -105,6 +105,7 @@ kpc-ai setup --client cursor --mode both
 kpc-ai setup --client claude --mode both
 kpc-ai setup --client vscode --mode mcp
 kpc-ai setup --client codex --mode both
+kpc-ai setup --client opencode --mode mcp
 ```
 
 写入前可以先预览：

--- a/docs/ai-cli.md
+++ b/docs/ai-cli.md
@@ -31,7 +31,6 @@ npx -y kpc-ai-cli list
 | `react` | `@king-design/react` | React 版本 |
 | `vue` | `@king-design/vue` | Vue 3 版本 |
 | `vue-legacy` | `@king-design/vue-legacy` | Vue 2 版本 |
-| `angular` | `kpc-angular` | Angular 示例查询目标 |
 
 ## 常用命令
 

--- a/docs/ai-cli.md
+++ b/docs/ai-cli.md
@@ -1,0 +1,120 @@
+---
+title: AI CLI
+order: 1.4
+sidebar: doc
+category: AI
+---
+
+# KPC AI CLI
+
+`kpc-ai-cli` 是面向 KPC / King Design 的 AI 辅助开发工具。它会将 KPC 组件文档、API、示例、设计说明整理成离线知识库，并同时提供命令行、MCP Server、Agent Skill 和 `llms.txt` 文档入口。
+
+当你使用 Cursor、Claude Code、VS Code、Codex 或其他支持 MCP 的 Agent 编写 KPC 代码时，可以先让 Agent 查询组件 API 和对应框架示例，再生成业务代码。
+
+## 安装
+
+```shell
+npm install -g kpc-ai-cli
+```
+
+也可以通过 `npx` 临时运行：
+
+```shell
+npx -y kpc-ai-cli list
+```
+
+## 支持的框架
+
+| 参数 | 包名 | 说明 |
+| --- | --- | --- |
+| `intact` | `@king-design/intact` | Intact 版本 |
+| `react` | `@king-design/react` | React 版本 |
+| `vue` | `@king-design/vue` | Vue 3 版本 |
+| `vue-legacy` | `@king-design/vue-legacy` | Vue 2 版本 |
+| `angular` | `kpc-angular` | Angular 示例查询目标 |
+
+## 常用命令
+
+列出组件：
+
+```shell
+kpc-ai list
+kpc-ai list --framework react
+```
+
+查询组件 API：
+
+```shell
+kpc-ai info Button --framework react
+kpc-ai info Table --framework vue --detail
+```
+
+输出组件完整文档：
+
+```shell
+kpc-ai doc Form --framework react --format markdown
+```
+
+查询示例代码：
+
+```shell
+kpc-ai demo Button basic --framework react --format markdown
+kpc-ai demo Table --framework vue
+```
+
+输出设计和 LLM 上下文：
+
+```shell
+kpc-ai design.md
+kpc-ai llms
+kpc-ai llms --full
+```
+
+## 输出格式
+
+所有查询命令都支持以下通用参数：
+
+```shell
+--format text|json|markdown
+--lang zh|en
+```
+
+其中 `json` 适合 Agent 和脚本消费，`markdown` 适合复制到需求文档或 LLM 上下文中。
+
+## 本地源码数据
+
+工具默认使用随包发布的离线数据。若你正在本地开发 KPC，可以在 `kpc-ai-cli` 仓库中从本地 KPC 源码重新抽取数据：
+
+```shell
+npm run extract -- --kpc-dir ../kpc
+npm run build
+```
+
+也可以显式指定 KPC 源码路径：
+
+```shell
+npm run extract -- --kpc-dir /path/to/kpc
+```
+
+## 与 Agent 配合使用
+
+推荐在项目中通过 setup 命令写入 MCP 或 Skill 配置：
+
+```shell
+kpc-ai setup --client cursor --mode both
+kpc-ai setup --client claude --mode both
+kpc-ai setup --client vscode --mode mcp
+kpc-ai setup --client codex --mode both
+```
+
+写入前可以先预览：
+
+```shell
+kpc-ai setup --client cursor --mode both --dry-run
+```
+
+检查当前项目是否已配置：
+
+```shell
+kpc-ai setup --client cursor --check
+```

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -1,0 +1,88 @@
+---
+title: Agent 使用指南
+order: 1.42
+sidebar: doc
+category: AI
+---
+
+# Agent 使用指南
+
+在使用 AI Agent 生成 KPC 代码时，建议先让 Agent 查询 KPC 官方组件知识，再开始写代码。这样可以减少组件名、属性、事件、插槽、框架差异写错的情况。
+
+## 推荐工作流
+
+1. 确认目标框架，例如 `react`、`vue`、`vue-legacy`、`intact` 或 `angular`。
+2. 使用 `kpc_list` 或 `kpc-ai list` 确认组件是否存在。
+3. 使用 `kpc_info` 或 `kpc-ai info` 查询组件 API。
+4. 使用 `kpc_demo` 或 `kpc-ai demo` 查询相近示例。
+5. 生成代码时遵守当前项目的框架、主题和已有组件写法。
+
+## 可直接使用的提示词
+
+```text
+这个项目使用 KPC / King Design。写组件代码前，请先通过 KPC MCP Server 或 kpc-ai 查询相关组件 API 和目标框架 demo，再生成代码。
+```
+
+React 项目：
+
+```text
+请使用 KPC React 版本。先查询相关组件的 react API 和 demo，注意 import 来自 @king-design/react，事件使用 React 写法。
+```
+
+Vue 3 项目：
+
+```text
+请使用 KPC Vue 3 版本。先查询相关组件的 vue API 和 demo，注意 v-model、事件和插槽写法。
+```
+
+Vue 2 项目：
+
+```text
+请使用 KPC Vue 2 版本。先查询 vue-legacy 目标的组件示例，不要混用 Vue 3 写法。
+```
+
+Intact 项目：
+
+```text
+请使用 KPC Intact 版本。先查询 intact 目标的组件 API 和 demo，保持 Intact 模板、事件和组件命名方式。
+```
+
+## 命令行查询示例
+
+```shell
+kpc-ai info Button --framework react --format json
+kpc-ai demo Button basic --framework react --format markdown
+kpc-ai info Form --framework vue --detail
+kpc-ai doc Table --framework intact --format markdown
+```
+
+## 适合放进项目规则的说明
+
+可以把下面内容加入项目的 Agent 规则文件，例如 `.cursor/rules/kpc.md`、`AGENTS.md` 或 Claude Code 项目说明：
+
+```md
+本项目使用 KPC / King Design。
+
+- 生成 KPC 代码前，优先使用 KPC MCP Server 或 `kpc-ai` 查询组件 API 和 demo。
+- 组件库版本以当前项目依赖为准，不要混用不同框架写法。
+- React 使用 `@king-design/react`。
+- Vue 3 使用 `@king-design/vue`。
+- Vue 2 使用 `@king-design/vue-legacy`。
+- Intact 使用 `@king-design/intact`。
+- 需要示例时优先查询 `kpc_demo`，需要完整文档时查询 `kpc_doc`。
+```
+
+也可以通过 setup 命令自动写入常见客户端配置：
+
+```shell
+kpc-ai setup --client cursor --mode both
+kpc-ai setup --client codex --mode both
+kpc-ai setup --client claude --mode both
+```
+
+## 注意事项
+
+- Agent 生成代码前，应先确认目标框架。
+- 组件名查询大小写不敏感，拼写不准确时工具会给出相近组件提示。
+- 如果某个 demo 暂时无法转换到目标框架，工具会返回 warning；可以查询其他框架示例作为参考。
+- `--format json` 更适合 Agent 自动读取，`--format markdown` 更适合人工查看和复制。

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -11,7 +11,7 @@ category: AI
 
 ## 推荐工作流
 
-1. 确认目标框架，例如 `react`、`vue`、`vue-legacy`、`intact` 或 `angular`。
+1. 确认目标框架，例如 `react`、`vue`、`vue-legacy` 或 `intact`。
 2. 使用 `kpc_list` 或 `kpc-ai list` 确认组件是否存在。
 3. 使用 `kpc_info` 或 `kpc-ai info` 查询组件 API。
 4. 使用 `kpc_demo` 或 `kpc-ai demo` 查询相近示例。

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -78,6 +78,7 @@ kpc-ai doc Table --framework intact --format markdown
 kpc-ai setup --client cursor --mode both
 kpc-ai setup --client codex --mode both
 kpc-ai setup --client claude --mode both
+kpc-ai setup --client opencode --mode mcp
 ```
 
 ## 注意事项

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -1,0 +1,82 @@
+---
+title: LLMs 文档
+order: 1.43
+sidebar: doc
+category: AI
+---
+
+# LLMs 文档
+
+`kpc-ai-cli` 会从 KPC 源码中抽取离线知识文件，供 LLM、Agent、搜索索引或其他自动化工具使用。
+
+## 文件说明
+
+| 文件 | 说明 |
+| --- | --- |
+| `data/kpc.json` | 结构化组件知识库，包含组件元信息、API、demo 和框架说明 |
+| `data/design.md` | 设计、主题和使用规范说明 |
+| `data/llms.txt` | 精简版 LLM 上下文，适合快速注入 |
+| `data/llms-full.txt` | 完整版 LLM 上下文，适合深度问答和代码生成 |
+
+普通用户通常不需要直接读取这些文件，可以通过 CLI 或 MCP 获取对应内容。
+
+## CLI 输出
+
+输出精简版上下文：
+
+```shell
+kpc-ai llms
+```
+
+输出完整上下文：
+
+```shell
+kpc-ai llms --full
+```
+
+输出设计说明：
+
+```shell
+kpc-ai design.md
+```
+
+## MCP 输出
+
+MCP Server 提供两个相关工具：
+
+| Tool | 说明 |
+| --- | --- |
+| `kpc_llms` | 返回精简或完整 LLM 上下文 |
+| `kpc_design_md` | 返回设计和主题说明 |
+
+可以让 Agent 在开始复杂任务前先读取这些内容：
+
+```text
+请先读取 KPC 的 llms 上下文和 design.md，再根据当前项目框架生成页面代码。
+```
+
+## 从源码重新生成
+
+如果你正在维护 KPC 或本地组件文档发生变化，可以从本地 KPC 仓库重新生成数据：
+
+```shell
+npm run extract -- --kpc-dir ../kpc
+```
+
+生成结果会更新：
+
+```text
+data/kpc.json
+data/design.md
+data/llms.txt
+data/llms-full.txt
+```
+
+发布 `kpc-ai-cli` npm 包时，这些数据会随包一起发布。用户安装后无需再拉取 KPC 源码。
+
+## 适用场景
+
+- 在 Agent 中注入 KPC 组件知识。
+- 为内部问答系统建立 KPC 文档索引。
+- 生成跨框架组件示例。
+- 在迁移代码时对比 Intact、React、Vue、Angular 的组件写法。

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -79,4 +79,4 @@ data/llms-full.txt
 - 在 Agent 中注入 KPC 组件知识。
 - 为内部问答系统建立 KPC 文档索引。
 - 生成跨框架组件示例。
-- 在迁移代码时对比 Intact、React、Vue、Angular 的组件写法。
+- 在迁移代码时对比 Intact、React、Vue 的组件写法。

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -58,12 +58,28 @@ kpc-ai setup --client cursor --mode mcp
 kpc-ai setup --client vscode --mode mcp
 kpc-ai setup --client claude --mode mcp
 kpc-ai setup --client codex --mode mcp
+kpc-ai setup --client opencode --mode mcp
 ```
 
 执行前预览将要写入的内容：
 
 ```shell
 kpc-ai setup --client cursor --mode mcp --dry-run
+```
+
+OpenCode 会写入项目根目录的 `opencode.json`：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "kpc": {
+      "type": "local",
+      "command": ["npx", "-y", "kpc-ai-cli", "mcp"],
+      "enabled": true
+    }
+  }
+}
 ```
 
 ## Tools

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,100 @@
+---
+title: MCP Server
+order: 1.41
+sidebar: doc
+category: AI
+---
+
+# MCP Server
+
+`kpc-ai-cli` 内置 KPC MCP Server，Agent 可以通过 MCP tools 查询组件列表、组件 API、完整文档、示例代码、设计说明和 LLM 上下文。
+
+## 启动
+
+```shell
+kpc-ai mcp
+```
+
+如果不想全局安装，也可以直接通过 `npx` 启动：
+
+```shell
+npx -y kpc-ai-cli mcp
+```
+
+## MCP 配置
+
+支持 MCP 的客户端通常可以使用下面的配置：
+
+```json
+{
+  "mcpServers": {
+    "kpc": {
+      "command": "npx",
+      "args": ["-y", "kpc-ai-cli", "mcp"]
+    }
+  }
+}
+```
+
+如果已经全局安装 `kpc-ai-cli`，也可以使用：
+
+```json
+{
+  "mcpServers": {
+    "kpc": {
+      "command": "kpc-ai",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## 自动配置
+
+可以使用 setup 命令为常见客户端写入配置：
+
+```shell
+kpc-ai setup --client cursor --mode mcp
+kpc-ai setup --client vscode --mode mcp
+kpc-ai setup --client claude --mode mcp
+kpc-ai setup --client codex --mode mcp
+```
+
+执行前预览将要写入的内容：
+
+```shell
+kpc-ai setup --client cursor --mode mcp --dry-run
+```
+
+## Tools
+
+| Tool | 说明 |
+| --- | --- |
+| `kpc_list` | 获取组件列表，可按框架过滤 |
+| `kpc_info` | 查询组件元信息、API、框架可用性 |
+| `kpc_doc` | 输出组件完整文档 |
+| `kpc_demo` | 查询组件 demo，可指定 demo 名和框架 |
+| `kpc_design_md` | 输出设计和主题相关说明 |
+| `kpc_llms` | 输出 compact 或 full 版本的 LLM 上下文 |
+
+## Prompts
+
+| Prompt | 适用场景 |
+| --- | --- |
+| `kpc-expert` | 编写或修改 KPC 组件代码前查询组件约束 |
+| `kpc-page-generator` | 根据需求生成 KPC 页面 |
+| `kpc-framework-migrator` | 在 Intact、React、Vue、Angular 之间迁移示例和写法 |
+
+## 示例请求
+
+让 Agent 生成 React 页面前，可以要求它先调用：
+
+```text
+使用 kpc_info 查询 Form、Input、Button 的 React API，再使用 kpc_demo 查询相关示例，最后生成页面代码。
+```
+
+如果需要迁移框架：
+
+```text
+使用 kpc_demo 查询 Table 的 intact 和 react 示例，对比事件、插槽和属性写法后迁移代码。
+```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -99,7 +99,7 @@ OpenCode 会写入项目根目录的 `opencode.json`：
 | --- | --- |
 | `kpc-expert` | 编写或修改 KPC 组件代码前查询组件约束 |
 | `kpc-page-generator` | 根据需求生成 KPC 页面 |
-| `kpc-framework-migrator` | 在 Intact、React、Vue、Angular 之间迁移示例和写法 |
+| `kpc-framework-migrator` | 在 Intact、React、Vue 之间迁移示例和写法 |
 
 ## 示例请求
 

--- a/scripts/doc/generate.js
+++ b/scripts/doc/generate.js
@@ -13,6 +13,10 @@ const globExp = resolvePath('./@(docs|components)/**/*.md');
 // const globExp = resolvePath('./@(docs|components)/menu/demos/recursive.md');
 // const globExp = resolvePath('./@(docs|components)/design_new/about.md');
 
+const sidebarCategoryOrders = {
+    doc: ['AI', '组件'],
+};
+
 function prepare() {
     return new Promise(resolve => {
         glob(globExp, null, (err, files) => {
@@ -82,12 +86,27 @@ function genereateSideBar(items) {
 
     return Promise.all(Object.keys(sidebars).map(name => {
         const data = sidebars[name];
-        Object.keys(data).forEach(key => {
+        const categories = Object.keys(data);
+        const categoryOrders = sidebarCategoryOrders[name];
+        if (categoryOrders) {
+            categories.sort((a, b) => {
+                const indexA = categoryOrders.indexOf(a);
+                const indexB = categoryOrders.indexOf(b);
+                if (indexA === -1 && indexB === -1) return 0;
+                if (indexA === -1) return 1;
+                if (indexB === -1) return -1;
+                return indexA - indexB;
+            });
+        }
+
+        const sortedData = {};
+        categories.forEach(key => {
             data[key].sort((a, b) => {
                 return (a.order || 0) - (b.order || 0);
             });
+            sortedData[key] = data[key];
         });
-        return writeFile(path.join(destData, `${name}.json`), JSON.stringify(data, null, 4));
+        return writeFile(path.join(destData, `${name}.json`), JSON.stringify(sortedData, null, 4));
     }));
 }
 


### PR DESCRIPTION
## Summary

Add documentation for `kpc-ai-cli`, an AI-oriented CLI and MCP server for KPC component usage.

This PR documents:

- KPC AI CLI installation and common commands
- MCP setup for Cursor, Claude, VS Code, Codex, and OpenCode
- Agent usage workflow for querying component APIs and demos before generating code
- `llms.txt` / `llms-full.txt` usage for LLM-friendly component context

It also updates the docs sidebar generation so the new AI documentation pages are grouped under an `AI` category.

## Notes

The CLI package itself lives outside this repository. These docs only describe how KPC users and AI agents can consume the generated KPC component knowledge.

Supported framework targets documented here are:

- Intact
- React
- Vue 3
- Vue 2

## Verification

- Checked the generated docs changes locally
- Verified the PR branch is mergeable with `master`