### PR TITLE
docs: add King Design AI CLI and MCP usage guides

### DIFF
--- a/components/datepicker/index.md
+++ b/components/datepicker/index.md
@@ -25,8 +25,8 @@ sidebar: doc
 | format | 指定日期格式化字符串 | `string` | `YYYY-MM-DD HH:mm:ss` |
 | valueFormat | 指定`value`值日期格式化字符串 | `string` | `undefined` |
 | showFormat | 指定展示的日期格式化字符串 | `string` | `undefined` |
-| max | 最大可选日期 | `Value` | `undefind` |
-| min | 最小可选日期 | `Value` | `undefind` |
+| max | 最大可选日期 | `Value` | `undefined` |
+| min | 最小可选日期 | `Value` | `undefined` |
 | disabledDate | 该属性值是一个函数，用于定义那些日期被禁止选择，函数参数为日期字符串，返回`true`则表示禁用该日期 | `(v: Dayjs) => boolean` | `undefined` |
 | type | 组件类型：`"date"` 只选择日期；`"datetime"` 选择日期和时间；`"year"` 选择年份；`"month"` 选择月份；`"week"` 选择周；`"quarter"` 选择季度 |  `"date"` &#124; `"datetime"` &#124; `"year"` &#124; `"month"` &#124; `"week"` &#124; `"quarter"` | `"date"` |
 | shortcuts | 指定快捷方式 | `Shortcut[]` | `undefined` |

--- a/components/message/index.md
+++ b/components/message/index.md
@@ -32,7 +32,7 @@ sidebar: doc
 | 参数名 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | content | 提示的内容，或者你也可以直接传入类型为<code>Partial&lt;MessageProps&gt;</code>的配置 | `string` &#124; `VNode` &#124; `Partial<MessageProps>` | `undefined` |
-| duration | 提示展示多长时间后自动关闭，当传入`0`时，提示将会一直展示。单位ms | `bumber` | `5000` |
+| duration | 提示展示多长时间后自动关闭，当传入`0`时，提示将会一直展示。单位ms | `number` | `5000` |
 
 ```ts
 import {VNode} from 'intact';

--- a/components/progress/demos/innerText.md
+++ b/components/progress/demos/innerText.md
@@ -3,7 +3,7 @@ title: 在进度条上展示百分比
 order: 1.1
 ---
 
-添加`inInnerText`属性，可以在进度条上展示百分比
+添加`showInnerText`属性，可以在进度条上展示百分比
 
 ```vdt
 import {Progress} from 'kpc';

--- a/components/select/index.md
+++ b/components/select/index.md
@@ -37,7 +37,7 @@ sidebar: doc
 | flat | 是否展示扁平样式 | `boolean` | `false` |
 | draggable | 多选值是否支持拖动排序 | `boolean` | `false` |
 | virtual | 是否开启虚拟列表 | `boolean` | `false` |
-| nowrap |  是否单行展示标签组，超出的部分会隐藏，仅展示隐藏数量 | `boolean` | `flase` |
+| nowrap |  是否单行展示标签组，超出的部分会隐藏，仅展示隐藏数量 | `boolean` | `false` |
 
 ```ts
 type Position = {

--- a/components/table/demos/pagination.md
+++ b/components/table/demos/pagination.md
@@ -4,7 +4,7 @@ order: 30
 ---
 
 给组件添加`pagination`属性即可开启分页功能，`pagination`支持`Pagination`组件的全部属性，当分页信息改变时
-会触发`changePage`事件
+会触发`page`事件
 
 > 需要给Table设置rowKey属性，否则选择的行翻页后依然会保留选中状态，因为不设置key，则使用索引当key，
 > 只要当前选中的索引在下一页存在，则会依然选中

--- a/components/timepicker/index.md
+++ b/components/timepicker/index.md
@@ -25,8 +25,8 @@ sidebar: doc
 | format | 指定日期格式化字符串 | `string` | `YYYY-MM-DD HH:mm:ss` |
 | valueFormat | 指定`value`值日期格式化字符串 | `string` | `undefined` |
 | showFormat | 指定展示的日期格式化字符串 | `string` | `undefined` |
-| max | 最大可选时间 | `Value` | `undefind` |
-| min | 最小可选时间 | `Value` | `undefind` |
+| max | 最大可选时间 | `Value` | `undefined` |
+| min | 最小可选时间 | `Value` | `undefined` |
 | disabledDate | 该属性值是一个函数，用于定义那些日期被禁止选择，函数参数为日期字符串，返回`true`则表示禁用该日期 | `(v: Dayjs) => boolean` | `undefined` |
 | step | 固定时间点的步长 | `string` | `undefined` |
 | position | 菜单弹出的位置，默认与触发器左侧对齐向下偏移`8px`的地方 | `Position` &#124; `"left"` &#124; `"bottom"` &#124; `"right"` &#124; `"top"` | `{my: 'left top+8', 'left bottom'}` |

--- a/components/tree/index.md
+++ b/components/tree/index.md
@@ -19,7 +19,7 @@ sidebar: doc
 | selectedKeys | 通过`key`指定选中的数据节点 | `K[]` | `undefined` |
 | multiple | `selectedKeys`是否支持多选 | `boolean` | `false` |
 | checkbox | 是否展示复选框 | `boolean` | `false` |
-| load | 指定异步加载节点数据的函数，该函数通过`Promise`返回数组来添加子节点数据 | <code>(node: TreeNode<K>) => Proomise<void> &#124; void</code> | `undefined` |
+| load | 指定异步加载节点数据的函数，该函数通过`Promise`返回数组来添加子节点数据 | <code>(node: TreeNode<K>) => Promise<void> &#124; void</code> | `undefined` |
 | showLine | 是否展示左侧对齐线 | `boolean` | `true` |
 | draggable | 是否支持拖拽 | `boolean` | `false` |
 | allowDrag | 指定哪些节点可拖拽 | `(node: TreeNode<K>) => boolean` | `undefined` |

--- a/components/treeSelect/index.md
+++ b/components/treeSelect/index.md
@@ -27,7 +27,7 @@ sidebar: doc
 | width | 指定宽度，组件自动添加单位`px` | `number` &#124; `string` | `undefined` | 
 | data | 要渲染的数据 | `TreeDataItem<K>[]` | `undefined` |
 | uncorrelated | 是否让父子`checkbox`选中状态互不关联 | `boolean` | `false` |
-| load | 指定异步加载节点数据的函数，该函数通过`Promise`返回数组来添加子节点数据 | <code>(node: TreeNode<K>) => Proomise<void> &#124; void</code> | `undefined` |
+| load | 指定异步加载节点数据的函数，该函数通过`Promise`返回数组来添加子节点数据 | <code>(node: TreeNode<K>) => Promise<void> &#124; void</code> | `undefined` |
 | showLine | 是否展示`Tree`的对齐线 | `boolean` | `true` |
 | defaultExpandAll | 是否默认展开所有节点 | `boolean` | `true` |
 | checkbox | 是否展示复选框 | `boolean` | `false` |

--- a/docs/ai-cli.md
+++ b/docs/ai-cli.md
@@ -105,6 +105,7 @@ kpc-ai setup --client cursor --mode both
 kpc-ai setup --client claude --mode both
 kpc-ai setup --client vscode --mode mcp
 kpc-ai setup --client codex --mode both
+kpc-ai setup --client opencode --mode mcp
 ```
 
 写入前可以先预览：

--- a/docs/ai-cli.md
+++ b/docs/ai-cli.md
@@ -31,7 +31,6 @@ npx -y kpc-ai-cli list
 | `react` | `@king-design/react` | React 版本 |
 | `vue` | `@king-design/vue` | Vue 3 版本 |
 | `vue-legacy` | `@king-design/vue-legacy` | Vue 2 版本 |
-| `angular` | `kpc-angular` | Angular 示例查询目标 |
 
 ## 常用命令
 

--- a/docs/ai-cli.md
+++ b/docs/ai-cli.md
@@ -1,0 +1,120 @@
+---
+title: AI CLI
+order: 1.4
+sidebar: doc
+category: AI
+---
+
+# KPC AI CLI
+
+`kpc-ai-cli` 是面向 KPC / King Design 的 AI 辅助开发工具。它会将 KPC 组件文档、API、示例、设计说明整理成离线知识库，并同时提供命令行、MCP Server、Agent Skill 和 `llms.txt` 文档入口。
+
+当你使用 Cursor、Claude Code、VS Code、Codex 或其他支持 MCP 的 Agent 编写 KPC 代码时，可以先让 Agent 查询组件 API 和对应框架示例，再生成业务代码。
+
+## 安装
+
+```shell
+npm install -g kpc-ai-cli
+```
+
+也可以通过 `npx` 临时运行：
+
+```shell
+npx -y kpc-ai-cli list
+```
+
+## 支持的框架
+
+| 参数 | 包名 | 说明 |
+| --- | --- | --- |
+| `intact` | `@king-design/intact` | Intact 版本 |
+| `react` | `@king-design/react` | React 版本 |
+| `vue` | `@king-design/vue` | Vue 3 版本 |
+| `vue-legacy` | `@king-design/vue-legacy` | Vue 2 版本 |
+| `angular` | `kpc-angular` | Angular 示例查询目标 |
+
+## 常用命令
+
+列出组件：
+
+```shell
+kpc-ai list
+kpc-ai list --framework react
+```
+
+查询组件 API：
+
+```shell
+kpc-ai info Button --framework react
+kpc-ai info Table --framework vue --detail
+```
+
+输出组件完整文档：
+
+```shell
+kpc-ai doc Form --framework react --format markdown
+```
+
+查询示例代码：
+
+```shell
+kpc-ai demo Button basic --framework react --format markdown
+kpc-ai demo Table --framework vue
+```
+
+输出设计和 LLM 上下文：
+
+```shell
+kpc-ai design.md
+kpc-ai llms
+kpc-ai llms --full
+```
+
+## 输出格式
+
+所有查询命令都支持以下通用参数：
+
+```shell
+--format text|json|markdown
+--lang zh|en
+```
+
+其中 `json` 适合 Agent 和脚本消费，`markdown` 适合复制到需求文档或 LLM 上下文中。
+
+## 本地源码数据
+
+工具默认使用随包发布的离线数据。若你正在本地开发 KPC，可以在 `kpc-ai-cli` 仓库中从本地 KPC 源码重新抽取数据：
+
+```shell
+npm run extract -- --kpc-dir ../kpc
+npm run build
+```
+
+也可以显式指定 KPC 源码路径：
+
+```shell
+npm run extract -- --kpc-dir /path/to/kpc
+```
+
+## 与 Agent 配合使用
+
+推荐在项目中通过 setup 命令写入 MCP 或 Skill 配置：
+
+```shell
+kpc-ai setup --client cursor --mode both
+kpc-ai setup --client claude --mode both
+kpc-ai setup --client vscode --mode mcp
+kpc-ai setup --client codex --mode both
+```
+
+写入前可以先预览：
+
+```shell
+kpc-ai setup --client cursor --mode both --dry-run
+```
+
+检查当前项目是否已配置：
+
+```shell
+kpc-ai setup --client cursor --check
+```

--- a/docs/ai-cli.md
+++ b/docs/ai-cli.md
@@ -5,22 +5,22 @@ sidebar: doc
 category: AI
 ---
 
-# KPC AI CLI
+# King Design AI CLI
 
-`kpc-ai-cli` 是面向 KPC / King Design 的 AI 辅助开发工具。它会将 KPC 组件文档、API、示例、设计说明整理成离线知识库，并同时提供命令行、MCP Server、Agent Skill 和 `llms.txt` 文档入口。
+`king-design-ai-cli` 是面向 King Design 的 AI 辅助开发工具。它会将 King Design 组件文档、API、示例、设计说明整理成离线知识库，并同时提供命令行、MCP Server、Agent Skill 和 `llms.txt` 文档入口。
 
-当你使用 Cursor、Claude Code、VS Code、Codex 或其他支持 MCP 的 Agent 编写 KPC 代码时，可以先让 Agent 查询组件 API 和对应框架示例，再生成业务代码。
+当你使用 Cursor、Claude Code、VS Code、Codex 或其他支持 MCP 的 Agent 编写 King Design 代码时，可以先让 Agent 查询组件 API 和对应框架示例，再生成业务代码。
 
 ## 安装
 
 ```shell
-npm install -g kpc-ai-cli
+npm install -g king-design-ai-cli
 ```
 
 也可以通过 `npx` 临时运行：
 
 ```shell
-npx -y kpc-ai-cli list
+npx -y king-design-ai-cli list
 ```
 
 ## 支持的框架
@@ -37,36 +37,36 @@ npx -y kpc-ai-cli list
 列出组件：
 
 ```shell
-kpc-ai list
-kpc-ai list --framework react
+king-design-ai list
+king-design-ai list --framework react
 ```
 
 查询组件 API：
 
 ```shell
-kpc-ai info Button --framework react
-kpc-ai info Table --framework vue --detail
+king-design-ai info Button --framework react
+king-design-ai info Table --framework vue --detail
 ```
 
 输出组件完整文档：
 
 ```shell
-kpc-ai doc Form --framework react --format markdown
+king-design-ai doc Form --framework react --format markdown
 ```
 
 查询示例代码：
 
 ```shell
-kpc-ai demo Button basic --framework react --format markdown
-kpc-ai demo Table --framework vue
+king-design-ai demo Button basic --framework react --format markdown
+king-design-ai demo Table --framework vue
 ```
 
 输出设计和 LLM 上下文：
 
 ```shell
-kpc-ai design.md
-kpc-ai llms
-kpc-ai llms --full
+king-design-ai design.md
+king-design-ai llms
+king-design-ai llms --full
 ```
 
 ## 输出格式
@@ -82,17 +82,17 @@ kpc-ai llms --full
 
 ## 本地源码数据
 
-工具默认使用随包发布的离线数据。若你正在本地开发 KPC，可以在 `kpc-ai-cli` 仓库中从本地 KPC 源码重新抽取数据：
+工具默认使用随包发布的离线数据。若你正在本地开发组件文档，可以在 `king-design-ai-cli` 仓库中从本地源码重新抽取数据：
 
 ```shell
-npm run extract -- --kpc-dir ../kpc
+npm run extract -- --king-design-dir ../kpc
 npm run build
 ```
 
-也可以显式指定 KPC 源码路径：
+也可以显式指定源码路径：
 
 ```shell
-npm run extract -- --kpc-dir /path/to/kpc
+npm run extract -- --king-design-dir /path/to/kpc
 ```
 
 ## 与 Agent 配合使用
@@ -100,21 +100,21 @@ npm run extract -- --kpc-dir /path/to/kpc
 推荐在项目中通过 setup 命令写入 MCP 或 Skill 配置：
 
 ```shell
-kpc-ai setup --client cursor --mode both
-kpc-ai setup --client claude --mode both
-kpc-ai setup --client vscode --mode mcp
-kpc-ai setup --client codex --mode both
-kpc-ai setup --client opencode --mode mcp
+king-design-ai setup --client cursor --mode both
+king-design-ai setup --client claude --mode both
+king-design-ai setup --client vscode --mode mcp
+king-design-ai setup --client codex --mode both
+king-design-ai setup --client opencode --mode mcp
 ```
 
 写入前可以先预览：
 
 ```shell
-kpc-ai setup --client cursor --mode both --dry-run
+king-design-ai setup --client cursor --mode both --dry-run
 ```
 
 检查当前项目是否已配置：
 
 ```shell
-kpc-ai setup --client cursor --check
+king-design-ai setup --client cursor --check
 ```

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -1,0 +1,88 @@
+---
+title: Agent 使用指南
+order: 1.42
+sidebar: doc
+category: AI
+---
+
+# Agent 使用指南
+
+在使用 AI Agent 生成 KPC 代码时，建议先让 Agent 查询 KPC 官方组件知识，再开始写代码。这样可以减少组件名、属性、事件、插槽、框架差异写错的情况。
+
+## 推荐工作流
+
+1. 确认目标框架，例如 `react`、`vue`、`vue-legacy`、`intact` 或 `angular`。
+2. 使用 `kpc_list` 或 `kpc-ai list` 确认组件是否存在。
+3. 使用 `kpc_info` 或 `kpc-ai info` 查询组件 API。
+4. 使用 `kpc_demo` 或 `kpc-ai demo` 查询相近示例。
+5. 生成代码时遵守当前项目的框架、主题和已有组件写法。
+
+## 可直接使用的提示词
+
+```text
+这个项目使用 KPC / King Design。写组件代码前，请先通过 KPC MCP Server 或 kpc-ai 查询相关组件 API 和目标框架 demo，再生成代码。
+```
+
+React 项目：
+
+```text
+请使用 KPC React 版本。先查询相关组件的 react API 和 demo，注意 import 来自 @king-design/react，事件使用 React 写法。
+```
+
+Vue 3 项目：
+
+```text
+请使用 KPC Vue 3 版本。先查询相关组件的 vue API 和 demo，注意 v-model、事件和插槽写法。
+```
+
+Vue 2 项目：
+
+```text
+请使用 KPC Vue 2 版本。先查询 vue-legacy 目标的组件示例，不要混用 Vue 3 写法。
+```
+
+Intact 项目：
+
+```text
+请使用 KPC Intact 版本。先查询 intact 目标的组件 API 和 demo，保持 Intact 模板、事件和组件命名方式。
+```
+
+## 命令行查询示例
+
+```shell
+kpc-ai info Button --framework react --format json
+kpc-ai demo Button basic --framework react --format markdown
+kpc-ai info Form --framework vue --detail
+kpc-ai doc Table --framework intact --format markdown
+```
+
+## 适合放进项目规则的说明
+
+可以把下面内容加入项目的 Agent 规则文件，例如 `.cursor/rules/kpc.md`、`AGENTS.md` 或 Claude Code 项目说明：
+
+```md
+本项目使用 KPC / King Design。
+
+- 生成 KPC 代码前，优先使用 KPC MCP Server 或 `kpc-ai` 查询组件 API 和 demo。
+- 组件库版本以当前项目依赖为准，不要混用不同框架写法。
+- React 使用 `@king-design/react`。
+- Vue 3 使用 `@king-design/vue`。
+- Vue 2 使用 `@king-design/vue-legacy`。
+- Intact 使用 `@king-design/intact`。
+- 需要示例时优先查询 `kpc_demo`，需要完整文档时查询 `kpc_doc`。
+```
+
+也可以通过 setup 命令自动写入常见客户端配置：
+
+```shell
+kpc-ai setup --client cursor --mode both
+kpc-ai setup --client codex --mode both
+kpc-ai setup --client claude --mode both
+```
+
+## 注意事项
+
+- Agent 生成代码前，应先确认目标框架。
+- 组件名查询大小写不敏感，拼写不准确时工具会给出相近组件提示。
+- 如果某个 demo 暂时无法转换到目标框架，工具会返回 warning；可以查询其他框架示例作为参考。
+- `--format json` 更适合 Agent 自动读取，`--format markdown` 更适合人工查看和复制。

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -7,78 +7,78 @@ category: AI
 
 # Agent 使用指南
 
-在使用 AI Agent 生成 KPC 代码时，建议先让 Agent 查询 KPC 官方组件知识，再开始写代码。这样可以减少组件名、属性、事件、插槽、框架差异写错的情况。
+在使用 AI Agent 生成 King Design 代码时，建议先让 Agent 查询 King Design 官方组件知识，再开始写代码。这样可以减少组件名、属性、事件、插槽、框架差异写错的情况。
 
 ## 推荐工作流
 
 1. 确认目标框架，例如 `react`、`vue`、`vue-legacy` 或 `intact`。
-2. 使用 `kpc_list` 或 `kpc-ai list` 确认组件是否存在。
-3. 使用 `kpc_info` 或 `kpc-ai info` 查询组件 API。
-4. 使用 `kpc_demo` 或 `kpc-ai demo` 查询相近示例。
+2. 使用 `king_design_list` 或 `king-design-ai list` 确认组件是否存在。
+3. 使用 `king_design_info` 或 `king-design-ai info` 查询组件 API。
+4. 使用 `king_design_demo` 或 `king-design-ai demo` 查询相近示例。
 5. 生成代码时遵守当前项目的框架、主题和已有组件写法。
 
 ## 可直接使用的提示词
 
 ```text
-这个项目使用 KPC / King Design。写组件代码前，请先通过 KPC MCP Server 或 kpc-ai 查询相关组件 API 和目标框架 demo，再生成代码。
+这个项目使用 King Design。写组件代码前，请先通过 King Design MCP Server 或 king-design-ai 查询相关组件 API 和目标框架 demo，再生成代码。
 ```
 
 React 项目：
 
 ```text
-请使用 KPC React 版本。先查询相关组件的 react API 和 demo，注意 import 来自 @king-design/react，事件使用 React 写法。
+请使用 King Design React 版本。先查询相关组件的 react API 和 demo，注意 import 来自 @king-design/react，事件使用 React 写法。
 ```
 
 Vue 3 项目：
 
 ```text
-请使用 KPC Vue 3 版本。先查询相关组件的 vue API 和 demo，注意 v-model、事件和插槽写法。
+请使用 King Design Vue 3 版本。先查询相关组件的 vue API 和 demo，注意 v-model、事件和插槽写法。
 ```
 
 Vue 2 项目：
 
 ```text
-请使用 KPC Vue 2 版本。先查询 vue-legacy 目标的组件示例，不要混用 Vue 3 写法。
+请使用 King Design Vue 2 版本。先查询 vue-legacy 目标的组件示例，不要混用 Vue 3 写法。
 ```
 
 Intact 项目：
 
 ```text
-请使用 KPC Intact 版本。先查询 intact 目标的组件 API 和 demo，保持 Intact 模板、事件和组件命名方式。
+请使用 King Design Intact 版本。先查询 intact 目标的组件 API 和 demo，保持 Intact 模板、事件和组件命名方式。
 ```
 
 ## 命令行查询示例
 
 ```shell
-kpc-ai info Button --framework react --format json
-kpc-ai demo Button basic --framework react --format markdown
-kpc-ai info Form --framework vue --detail
-kpc-ai doc Table --framework intact --format markdown
+king-design-ai info Button --framework react --format json
+king-design-ai demo Button basic --framework react --format markdown
+king-design-ai info Form --framework vue --detail
+king-design-ai doc Table --framework intact --format markdown
 ```
 
 ## 适合放进项目规则的说明
 
-可以把下面内容加入项目的 Agent 规则文件，例如 `.cursor/rules/kpc.md`、`AGENTS.md` 或 Claude Code 项目说明：
+可以把下面内容加入项目的 Agent 规则文件，例如 `.cursor/rules/king-design.md`、`AGENTS.md` 或 Claude Code 项目说明：
 
 ```md
-本项目使用 KPC / King Design。
+本项目使用 King Design。
 
-- 生成 KPC 代码前，优先使用 KPC MCP Server 或 `kpc-ai` 查询组件 API 和 demo。
+- 生成 King Design 代码前，优先使用 King Design MCP Server 或 `king-design-ai` 查询组件 API 和 demo。
 - 组件库版本以当前项目依赖为准，不要混用不同框架写法。
 - React 使用 `@king-design/react`。
 - Vue 3 使用 `@king-design/vue`。
 - Vue 2 使用 `@king-design/vue-legacy`。
 - Intact 使用 `@king-design/intact`。
-- 需要示例时优先查询 `kpc_demo`，需要完整文档时查询 `kpc_doc`。
+- 需要示例时优先查询 `king_design_demo`，需要完整文档时查询 `king_design_doc`。
 ```
 
 也可以通过 setup 命令自动写入常见客户端配置：
 
 ```shell
-kpc-ai setup --client cursor --mode both
-kpc-ai setup --client codex --mode both
-kpc-ai setup --client claude --mode both
-kpc-ai setup --client opencode --mode mcp
+king-design-ai setup --client cursor --mode both
+king-design-ai setup --client codex --mode both
+king-design-ai setup --client claude --mode both
+king-design-ai setup --client opencode --mode mcp
 ```
 
 ## 注意事项

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -11,7 +11,7 @@ category: AI
 
 ## 推荐工作流
 
-1. 确认目标框架，例如 `react`、`vue`、`vue-legacy`、`intact` 或 `angular`。
+1. 确认目标框架，例如 `react`、`vue`、`vue-legacy` 或 `intact`。
 2. 使用 `kpc_list` 或 `kpc-ai list` 确认组件是否存在。
 3. 使用 `kpc_info` 或 `kpc-ai info` 查询组件 API。
 4. 使用 `kpc_demo` 或 `kpc-ai demo` 查询相近示例。

--- a/docs/for-agents.md
+++ b/docs/for-agents.md
@@ -78,6 +78,7 @@ kpc-ai doc Table --framework intact --format markdown
 kpc-ai setup --client cursor --mode both
 kpc-ai setup --client codex --mode both
 kpc-ai setup --client claude --mode both
+kpc-ai setup --client opencode --mode mcp
 ```
 
 ## 注意事项

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -1,0 +1,82 @@
+---
+title: LLMs 文档
+order: 1.43
+sidebar: doc
+category: AI
+---
+
+# LLMs 文档
+
+`kpc-ai-cli` 会从 KPC 源码中抽取离线知识文件，供 LLM、Agent、搜索索引或其他自动化工具使用。
+
+## 文件说明
+
+| 文件 | 说明 |
+| --- | --- |
+| `data/kpc.json` | 结构化组件知识库，包含组件元信息、API、demo 和框架说明 |
+| `data/design.md` | 设计、主题和使用规范说明 |
+| `data/llms.txt` | 精简版 LLM 上下文，适合快速注入 |
+| `data/llms-full.txt` | 完整版 LLM 上下文，适合深度问答和代码生成 |
+
+普通用户通常不需要直接读取这些文件，可以通过 CLI 或 MCP 获取对应内容。
+
+## CLI 输出
+
+输出精简版上下文：
+
+```shell
+kpc-ai llms
+```
+
+输出完整上下文：
+
+```shell
+kpc-ai llms --full
+```
+
+输出设计说明：
+
+```shell
+kpc-ai design.md
+```
+
+## MCP 输出
+
+MCP Server 提供两个相关工具：
+
+| Tool | 说明 |
+| --- | --- |
+| `kpc_llms` | 返回精简或完整 LLM 上下文 |
+| `kpc_design_md` | 返回设计和主题说明 |
+
+可以让 Agent 在开始复杂任务前先读取这些内容：
+
+```text
+请先读取 KPC 的 llms 上下文和 design.md，再根据当前项目框架生成页面代码。
+```
+
+## 从源码重新生成
+
+如果你正在维护 KPC 或本地组件文档发生变化，可以从本地 KPC 仓库重新生成数据：
+
+```shell
+npm run extract -- --kpc-dir ../kpc
+```
+
+生成结果会更新：
+
+```text
+data/kpc.json
+data/design.md
+data/llms.txt
+data/llms-full.txt
+```
+
+发布 `kpc-ai-cli` npm 包时，这些数据会随包一起发布。用户安装后无需再拉取 KPC 源码。
+
+## 适用场景
+
+- 在 Agent 中注入 KPC 组件知识。
+- 为内部问答系统建立 KPC 文档索引。
+- 生成跨框架组件示例。
+- 在迁移代码时对比 Intact、React、Vue、Angular 的组件写法。

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -79,4 +79,4 @@ data/llms-full.txt
 - 在 Agent 中注入 KPC 组件知识。
 - 为内部问答系统建立 KPC 文档索引。
 - 生成跨框架组件示例。
-- 在迁移代码时对比 Intact、React、Vue、Angular 的组件写法。
+- 在迁移代码时对比 Intact、React、Vue 的组件写法。

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -7,13 +7,13 @@ category: AI
 
 # LLMs 文档
 
-`kpc-ai-cli` 会从 KPC 源码中抽取离线知识文件，供 LLM、Agent、搜索索引或其他自动化工具使用。
+`king-design-ai-cli` 会从本仓库源码中抽取离线知识文件，供 LLM、Agent、搜索索引或其他自动化工具使用。
 
 ## 文件说明
 
 | 文件 | 说明 |
 | --- | --- |
-| `data/kpc.json` | 结构化组件知识库，包含组件元信息、API、demo 和框架说明 |
+| `data/king-design.json` | 结构化组件知识库，包含组件元信息、API、demo 和框架说明 |
 | `data/design.md` | 设计、主题和使用规范说明 |
 | `data/llms.txt` | 精简版 LLM 上下文，适合快速注入 |
 | `data/llms-full.txt` | 完整版 LLM 上下文，适合深度问答和代码生成 |
@@ -25,19 +25,19 @@ category: AI
 输出精简版上下文：
 
 ```shell
-kpc-ai llms
+king-design-ai llms
 ```
 
 输出完整上下文：
 
 ```shell
-kpc-ai llms --full
+king-design-ai llms --full
 ```
 
 输出设计说明：
 
 ```shell
-kpc-ai design.md
+king-design-ai design.md
 ```
 
 ## MCP 输出
@@ -46,37 +46,37 @@ MCP Server 提供两个相关工具：
 
 | Tool | 说明 |
 | --- | --- |
-| `kpc_llms` | 返回精简或完整 LLM 上下文 |
-| `kpc_design_md` | 返回设计和主题说明 |
+| `king_design_llms` | 返回精简或完整 LLM 上下文 |
+| `king_design_md` | 返回设计和主题说明 |
 
 可以让 Agent 在开始复杂任务前先读取这些内容：
 
 ```text
-请先读取 KPC 的 llms 上下文和 design.md，再根据当前项目框架生成页面代码。
+请先读取 King Design 的 llms 上下文和 design.md，再根据当前项目框架生成页面代码。
 ```
 
 ## 从源码重新生成
 
-如果你正在维护 KPC 或本地组件文档发生变化，可以从本地 KPC 仓库重新生成数据：
+如果你正在维护组件文档或本地组件文档发生变化，可以从本地仓库重新生成数据：
 
 ```shell
-npm run extract -- --kpc-dir ../kpc
+npm run extract -- --king-design-dir ../kpc
 ```
 
 生成结果会更新：
 
 ```text
-data/kpc.json
+data/king-design.json
 data/design.md
 data/llms.txt
 data/llms-full.txt
 ```
 
-发布 `kpc-ai-cli` npm 包时，这些数据会随包一起发布。用户安装后无需再拉取 KPC 源码。
+发布 `king-design-ai-cli` npm 包时，这些数据会随包一起发布。用户安装后无需再拉取源码。
 
 ## 适用场景
 
-- 在 Agent 中注入 KPC 组件知识。
-- 为内部问答系统建立 KPC 文档索引。
+- 在 Agent 中注入 King Design 组件知识。
+- 为内部问答系统建立 King Design 文档索引。
 - 生成跨框架组件示例。
 - 在迁移代码时对比 Intact、React、Vue 的组件写法。

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -58,12 +58,28 @@ kpc-ai setup --client cursor --mode mcp
 kpc-ai setup --client vscode --mode mcp
 kpc-ai setup --client claude --mode mcp
 kpc-ai setup --client codex --mode mcp
+kpc-ai setup --client opencode --mode mcp
 ```
 
 执行前预览将要写入的内容：
 
 ```shell
 kpc-ai setup --client cursor --mode mcp --dry-run
+```
+
+OpenCode 会写入项目根目录的 `opencode.json`：
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "kpc": {
+      "type": "local",
+      "command": ["npx", "-y", "kpc-ai-cli", "mcp"],
+      "enabled": true
+    }
+  }
+}
 ```
 
 ## Tools

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,100 @@
+---
+title: MCP Server
+order: 1.41
+sidebar: doc
+category: AI
+---
+
+# MCP Server
+
+`kpc-ai-cli` 内置 KPC MCP Server，Agent 可以通过 MCP tools 查询组件列表、组件 API、完整文档、示例代码、设计说明和 LLM 上下文。
+
+## 启动
+
+```shell
+kpc-ai mcp
+```
+
+如果不想全局安装，也可以直接通过 `npx` 启动：
+
+```shell
+npx -y kpc-ai-cli mcp
+```
+
+## MCP 配置
+
+支持 MCP 的客户端通常可以使用下面的配置：
+
+```json
+{
+  "mcpServers": {
+    "kpc": {
+      "command": "npx",
+      "args": ["-y", "kpc-ai-cli", "mcp"]
+    }
+  }
+}
+```
+
+如果已经全局安装 `kpc-ai-cli`，也可以使用：
+
+```json
+{
+  "mcpServers": {
+    "kpc": {
+      "command": "kpc-ai",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## 自动配置
+
+可以使用 setup 命令为常见客户端写入配置：
+
+```shell
+kpc-ai setup --client cursor --mode mcp
+kpc-ai setup --client vscode --mode mcp
+kpc-ai setup --client claude --mode mcp
+kpc-ai setup --client codex --mode mcp
+```
+
+执行前预览将要写入的内容：
+
+```shell
+kpc-ai setup --client cursor --mode mcp --dry-run
+```
+
+## Tools
+
+| Tool | 说明 |
+| --- | --- |
+| `kpc_list` | 获取组件列表，可按框架过滤 |
+| `kpc_info` | 查询组件元信息、API、框架可用性 |
+| `kpc_doc` | 输出组件完整文档 |
+| `kpc_demo` | 查询组件 demo，可指定 demo 名和框架 |
+| `kpc_design_md` | 输出设计和主题相关说明 |
+| `kpc_llms` | 输出 compact 或 full 版本的 LLM 上下文 |
+
+## Prompts
+
+| Prompt | 适用场景 |
+| --- | --- |
+| `kpc-expert` | 编写或修改 KPC 组件代码前查询组件约束 |
+| `kpc-page-generator` | 根据需求生成 KPC 页面 |
+| `kpc-framework-migrator` | 在 Intact、React、Vue、Angular 之间迁移示例和写法 |
+
+## 示例请求
+
+让 Agent 生成 React 页面前，可以要求它先调用：
+
+```text
+使用 kpc_info 查询 Form、Input、Button 的 React API，再使用 kpc_demo 查询相关示例，最后生成页面代码。
+```
+
+如果需要迁移框架：
+
+```text
+使用 kpc_demo 查询 Table 的 intact 和 react 示例，对比事件、插槽和属性写法后迁移代码。
+```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,18 +7,18 @@ category: AI
 
 # MCP Server
 
-`kpc-ai-cli` 内置 KPC MCP Server，Agent 可以通过 MCP tools 查询组件列表、组件 API、完整文档、示例代码、设计说明和 LLM 上下文。
+`king-design-ai-cli` 内置 King Design MCP Server，Agent 可以通过 MCP tools 查询组件列表、组件 API、完整文档、示例代码、设计说明和 LLM 上下文。
 
 ## 启动
 
 ```shell
-kpc-ai mcp
+king-design-ai mcp
 ```
 
 如果不想全局安装，也可以直接通过 `npx` 启动：
 
 ```shell
-npx -y kpc-ai-cli mcp
+npx -y king-design-ai-cli mcp
 ```
 
 ## MCP 配置
@@ -28,21 +28,21 @@ npx -y kpc-ai-cli mcp
 ```json
 {
   "mcpServers": {
-    "kpc": {
+    "king-design": {
       "command": "npx",
-      "args": ["-y", "kpc-ai-cli", "mcp"]
+      "args": ["-y", "king-design-ai-cli", "mcp"]
     }
   }
 }
 ```
 
-如果已经全局安装 `kpc-ai-cli`，也可以使用：
+如果已经全局安装 `king-design-ai-cli`，也可以使用：
 
 ```json
 {
   "mcpServers": {
-    "kpc": {
-      "command": "kpc-ai",
+    "king-design": {
+      "command": "king-design-ai",
       "args": ["mcp"]
     }
   }
@@ -54,17 +54,17 @@ npx -y kpc-ai-cli mcp
 可以使用 setup 命令为常见客户端写入配置：
 
 ```shell
-kpc-ai setup --client cursor --mode mcp
-kpc-ai setup --client vscode --mode mcp
-kpc-ai setup --client claude --mode mcp
-kpc-ai setup --client codex --mode mcp
-kpc-ai setup --client opencode --mode mcp
+king-design-ai setup --client cursor --mode mcp
+king-design-ai setup --client vscode --mode mcp
+king-design-ai setup --client claude --mode mcp
+king-design-ai setup --client codex --mode mcp
+king-design-ai setup --client opencode --mode mcp
 ```
 
 执行前预览将要写入的内容：
 
 ```shell
-kpc-ai setup --client cursor --mode mcp --dry-run
+king-design-ai setup --client cursor --mode mcp --dry-run
 ```
 
 OpenCode 会写入项目根目录的 `opencode.json`：
@@ -73,9 +73,9 @@ OpenCode 会写入项目根目录的 `opencode.json`：
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "kpc": {
+    "king-design": {
       "type": "local",
-      "command": ["npx", "-y", "kpc-ai-cli", "mcp"],
+      "command": ["npx", "-y", "king-design-ai-cli", "mcp"],
       "enabled": true
     }
   }
@@ -86,31 +86,31 @@ OpenCode 会写入项目根目录的 `opencode.json`：
 
 | Tool | 说明 |
 | --- | --- |
-| `kpc_list` | 获取组件列表，可按框架过滤 |
-| `kpc_info` | 查询组件元信息、API、框架可用性 |
-| `kpc_doc` | 输出组件完整文档 |
-| `kpc_demo` | 查询组件 demo，可指定 demo 名和框架 |
-| `kpc_design_md` | 输出设计和主题相关说明 |
-| `kpc_llms` | 输出 compact 或 full 版本的 LLM 上下文 |
+| `king_design_list` | 获取组件列表，可按框架过滤 |
+| `king_design_info` | 查询组件元信息、API、框架可用性 |
+| `king_design_doc` | 输出组件完整文档 |
+| `king_design_demo` | 查询组件 demo，可指定 demo 名和框架 |
+| `king_design_md` | 输出设计和主题相关说明 |
+| `king_design_llms` | 输出 compact 或 full 版本的 LLM 上下文 |
 
 ## Prompts
 
 | Prompt | 适用场景 |
 | --- | --- |
-| `kpc-expert` | 编写或修改 KPC 组件代码前查询组件约束 |
-| `kpc-page-generator` | 根据需求生成 KPC 页面 |
-| `kpc-framework-migrator` | 在 Intact、React、Vue 之间迁移示例和写法 |
+| `king-design-expert` | 编写或修改 King Design 组件代码前查询组件约束 |
+| `king-design-page-generator` | 根据需求生成 King Design 页面 |
+| `king-design-framework-migrator` | 在 Intact、React、Vue 之间迁移示例和写法 |
 
 ## 示例请求
 
 让 Agent 生成 React 页面前，可以要求它先调用：
 
 ```text
-使用 kpc_info 查询 Form、Input、Button 的 React API，再使用 kpc_demo 查询相关示例，最后生成页面代码。
+使用 king_design_info 查询 Form、Input、Button 的 React API，再使用 king_design_demo 查询相关示例，最后生成页面代码。
 ```
 
 如果需要迁移框架：
 
 ```text
-使用 kpc_demo 查询 Table 的 intact 和 react 示例，对比事件、插槽和属性写法后迁移代码。
+使用 king_design_demo 查询 Table 的 intact 和 react 示例，对比事件、插槽和属性写法后迁移代码。
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -99,7 +99,7 @@ OpenCode 会写入项目根目录的 `opencode.json`：
 | --- | --- |
 | `kpc-expert` | 编写或修改 KPC 组件代码前查询组件约束 |
 | `kpc-page-generator` | 根据需求生成 KPC 页面 |
-| `kpc-framework-migrator` | 在 Intact、React、Vue、Angular 之间迁移示例和写法 |
+| `kpc-framework-migrator` | 在 Intact、React、Vue 之间迁移示例和写法 |
 
 ## 示例请求
 

--- a/scripts/doc/generate.js
+++ b/scripts/doc/generate.js
@@ -13,6 +13,10 @@ const globExp = resolvePath('./@(docs|components)/**/*.md');
 // const globExp = resolvePath('./@(docs|components)/menu/demos/recursive.md');
 // const globExp = resolvePath('./@(docs|components)/design_new/about.md');
 
+const sidebarCategoryOrders = {
+    doc: ['AI', '组件'],
+};
+
 function prepare() {
     return new Promise(resolve => {
         glob(globExp, null, (err, files) => {
@@ -82,12 +86,27 @@ function genereateSideBar(items) {
 
     return Promise.all(Object.keys(sidebars).map(name => {
         const data = sidebars[name];
-        Object.keys(data).forEach(key => {
+        const categories = Object.keys(data);
+        const categoryOrders = sidebarCategoryOrders[name];
+        if (categoryOrders) {
+            categories.sort((a, b) => {
+                const indexA = categoryOrders.indexOf(a);
+                const indexB = categoryOrders.indexOf(b);
+                if (indexA === -1 && indexB === -1) return 0;
+                if (indexA === -1) return 1;
+                if (indexB === -1) return -1;
+                return indexA - indexB;
+            });
+        }
+
+        const sortedData = {};
+        categories.forEach(key => {
             data[key].sort((a, b) => {
                 return (a.order || 0) - (b.order || 0);
             });
+            sortedData[key] = data[key];
         });
-        return writeFile(path.join(destData, `${name}.json`), JSON.stringify(data, null, 4));
+        return writeFile(path.join(destData, `${name}.json`), JSON.stringify(sortedData, null, 4));
     }));
 }
 


### PR DESCRIPTION
## Summary

Add documentation for `king-design-ai-cli`, an AI-oriented CLI and MCP server for King Design component usage.

This PR documents:

- King Design AI CLI installation and common commands
- MCP setup for Cursor, Claude, VS Code, Codex, and OpenCode
- Agent usage workflow for querying component APIs and demos before generating code
- `llms.txt` / `llms-full.txt` usage for LLM-friendly component context

It also updates the docs sidebar generation so the new AI documentation pages are grouped under an `AI` category.

## Notes

The CLI package itself lives outside this repository. These docs only describe how King Design users and AI agents can consume the generated component knowledge.

Supported framework targets documented here are:

- Intact
- React
- Vue 3
- Vue 2

## MCP tools and prompts

Tools:

- `king_design_list`
- `king_design_info`
- `king_design_doc`
- `king_design_demo`
- `king_design_md`
- `king_design_llms`

Prompts:

- `king-design-expert`
- `king-design-page-generator`
- `king-design-framework-migrator`

## Verification

- Verified the documentation branch is mergeable with `master`
- Verified the AI docs only reference the King Design AI CLI naming
- Verified the CLI package build/test/pack flow in the external package repository